### PR TITLE
Update convert-source-maps for correct comment style, etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "coffee-script": ">= 1.6.0",
     "mkdirp": ">= 0.3.1",
-    "convert-source-map": "~0.2.5"
+    "convert-source-map": "~1.1.0"
   },
   "devDependencies": {},
   "optionalDependencies": {},


### PR DESCRIPTION
This is prompted by deprecated sourcemap comment style and these ugly console messages:

```Using //@ to indicate sourceMappingURL pragmas is deprecated. Use //# instead```

The rest of the module looks good, so it appears a dependency bump is the only thing needed: convert-source-maps 0.2.5 -> 1.1.0.

I leave module versioning to you all. Cheers!